### PR TITLE
Fixed incorrect column name in round_trips.gen_round_trip_stats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "matplotlib >=1.4.0",
     "numpy >=1.11.1",
     "pandas >=1.3",
+    "parameterized >=0.9.0",
     "pytz >=2014.10",
     "scipy >=0.14.0",
     "scikit-learn >=0.16.1",
@@ -104,6 +105,8 @@ minversion = "6.0"
 testpaths = 'tests'
 addopts = '-v'
 
+[tool.pytest.ini_options]
+pythonpath = "src/"
 
 [tool.cibuildwheel]
 test-extras = "test"

--- a/src/pyfolio/round_trips.py
+++ b/src/pyfolio/round_trips.py
@@ -383,9 +383,9 @@ def gen_round_trip_stats(round_trips):
     stats["pnl"] = agg_all_long_short(round_trips, "pnl", PNL_STATS)
     stats["summary"] = agg_all_long_short(round_trips, "pnl", SUMMARY_STATS)
     stats["duration"] = agg_all_long_short(round_trips, "duration", DURATION_STATS)
-    stats["returns"] = agg_all_long_short(round_trips, "returns", RETURN_STATS)
+    stats["returns"] = agg_all_long_short(round_trips, "rt_returns", RETURN_STATS)
 
-    stats["symbols"] = round_trips.groupby("symbol")["returns"].agg(RETURN_STATS).T
+    stats["symbols"] = round_trips.groupby("symbol")["rt_returns"].agg(RETURN_STATS).T
 
     return stats
 

--- a/tests/test_round_trips.py
+++ b/tests/test_round_trips.py
@@ -19,6 +19,7 @@ from pyfolio.round_trips import (
     extract_round_trips,
     add_closing_transactions,
     _groupby_consecutive,
+    gen_round_trip_stats
 )
 
 
@@ -255,6 +256,9 @@ class RoundTripTestCase(TestCase):
             round_trips.sort_index(axis="columns"),
             expected.sort_index(axis="columns"),
         )
+
+        #would be better to test something specific but just running them is an improvement
+        gen_round_trip_stats(round_trips)
 
     def test_add_closing_trades(self):
         dates = date_range(start="2015-01-01", periods=20)


### PR DESCRIPTION
Calls to gen_round_trips_stats failed due to a wrong column name.  Fixed and added a generic call in the test cases to make sure a call will go through.