### PR TITLE
Handle empty returns in top drawdown extraction

### DIFF
--- a/src/pyfolio/timeseries.py
+++ b/src/pyfolio/timeseries.py
@@ -945,7 +945,11 @@ def get_top_drawdowns(returns, top=10):
     -------
     drawdowns : list
         List of drawdown peaks, valleys, and recoveries. See get_max_drawdown.
+        Returns an empty list when returns is empty.
     """
+
+    if returns.empty:
+        return []
 
     returns = returns.copy()
     df_cum = ep.cum_returns(returns, 1.0)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -15,6 +15,18 @@ DECIMAL_PLACES = 8
 
 
 class TestDrawdown(TestCase):
+    @parameterized.expand([(0,), (1,), (10,)])
+    def test_empty_top_drawdowns(self, top):
+        returns = pd.Series(dtype=float, index=pd.DatetimeIndex([]))
+        self.assertEqual(timeseries.get_top_drawdowns(returns, top=top), [])
+        self.assertTrue(returns.empty)
+
+    def test_empty_drawdown_table(self):
+        returns = pd.Series(dtype=float, index=pd.DatetimeIndex([]))
+        result = timeseries.gen_drawdown_table(returns, top=3)
+        self.assertEqual(result.shape, (3, 5))
+        self.assertTrue(result.isna().all().all())
+
     drawdown_list = np.array([100, 90, 75]) / 10.0
     dt = pd.date_range("2000-1-3", periods=3, freq="D")
 


### PR DESCRIPTION
## Summary

Return an empty drawdown list immediately when `get_top_drawdowns` receives an empty returns Series. Previously the function attempted `idxmin()` on an empty underwater series before reaching its existing empty-input check.

This addresses the drawdown-extraction exception reported in #54. It does not repair the upstream failed data download or claim that every tear-sheet plot supports empty inputs. Nonempty inputs retain their current behavior, and `gen_drawdown_table` keeps its existing `top`-row shape with missing values when there are no drawdowns.

## Verification

- Added four cases: empty returns with `top=0`, `top=1`, `top=10`, and an empty drawdown table.
- Before the fix, the three cases involving extraction with positive `top` failed with `ValueError: attempt to get argmin of an empty sequence`.
- `MPLBACKEND=Agg python -m pytest tests -q --tb=short`: **84 passed** (warnings from existing code/dependencies).
- Black and Flake8 on both changed files: passed.
- `git diff --check`: passed.

Tested on Python 3.12 with pandas 2.3.3 and NumPy 1.26.4. No external data downloads were needed.
